### PR TITLE
Configuration options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@
 # IntelliJ IDEA
 /.idea
 *.iml
+
+# Eclipse
+.project
+.classpath
+.settings

--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,7 @@
                     </execution>
                 </executions>
             </plugin>
+            <!--
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
@@ -104,6 +105,7 @@
                     </execution>
                 </executions>
             </plugin>
+            -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>

--- a/src/main/java/org/zalando/stups/tokens/AccessTokensBuilder.java
+++ b/src/main/java/org/zalando/stups/tokens/AccessTokensBuilder.java
@@ -1,6 +1,7 @@
 package org.zalando.stups.tokens;
 
 import java.net.URI;
+
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
@@ -8,8 +9,8 @@ import java.util.Set;
 public class AccessTokensBuilder {
     private final URI accessTokenUri;
 
-    private ClientCredentialsProvider clientCredentialsProvider = new JsonFileBackedClientCredentialsProvider();
-    private UserCredentialsProvider userCredentialsProvider = new JsonFileBackedUserCredentialsProvider();
+    private ClientCredentialsProvider clientCredentialsProvider = null;
+    private UserCredentialsProvider userCredentialsProvider = null;
     private int refreshPercentLeft = 40;
     private int warnPercentLeft = 20;
 
@@ -33,7 +34,8 @@ public class AccessTokensBuilder {
         }
     }
 
-    public AccessTokensBuilder usingClientCredentialsProvider(final ClientCredentialsProvider clientCredentialsProvider) {
+    public AccessTokensBuilder usingClientCredentialsProvider(
+            final ClientCredentialsProvider clientCredentialsProvider) {
         checkLock();
         checkNotNull("clientCredentialsProvider", clientCredentialsProvider);
         this.clientCredentialsProvider = clientCredentialsProvider;
@@ -62,6 +64,7 @@ public class AccessTokensBuilder {
     public AccessTokenConfiguration manageToken(final Object tokenId) {
         checkLock();
         checkNotNull("tokenId", tokenId);
+
         final AccessTokenConfiguration config = new AccessTokenConfiguration(tokenId, this);
         accessTokenConfigurations.add(config);
         return config;
@@ -95,7 +98,20 @@ public class AccessTokensBuilder {
         if (accessTokenConfigurations.size() == 0) {
             throw new IllegalArgumentException("no scopes defined");
         }
+
         locked = true;
+        if (clientCredentialsProvider == null) {
+
+            // use default
+            clientCredentialsProvider = new JsonFileBackedClientCredentialsProvider();
+        }
+
+        if (userCredentialsProvider == null) {
+
+            // use default
+            userCredentialsProvider = new JsonFileBackedUserCredentialsProvider();
+        }
+
         final AccessTokenRefresher refresher = new AccessTokenRefresher(this);
         refresher.run();
         refresher.start();


### PR DESCRIPTION
With initialization of client- and user- credentialsprovider via default
when the AccessTokensBuilder is created it will always throws an
exception when the 'CREDENTIALS_DIR' is not set as environment-variable.
But I think you want to make it possible to do so because you provide
constructors with File arguments that do not check 'CREDENTIALS_DIR'
what I like and use in spring-boot-stups-tokens. With this small change
it should be possible to fully configure AccessTokensBuilder and be safe
credentialsProvider are never be null without being bound to
'CREDENTIALS_DIR' as environment variable. Maybe it is already in use
for something different.