### PR TITLE
AccessTokenEndpointException includes response details if available

### DIFF
--- a/src/main/java/org/zalando/stups/tokens/AccessTokenEndpointException.java
+++ b/src/main/java/org/zalando/stups/tokens/AccessTokenEndpointException.java
@@ -1,6 +1,30 @@
 package org.zalando.stups.tokens;
 
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.util.EntityUtils;
+
+import java.io.IOException;
+
 public class AccessTokenEndpointException extends IllegalStateException {
+
+    public static AccessTokenEndpointException from(HttpResponse response) {
+        final StringBuilder message = new StringBuilder();
+        message.append(response.getStatusLine().toString());
+
+        final HttpEntity entity = response.getEntity();
+        if (entity != null) {
+            message.append("\n").append("Response Body:").append("\n");
+            try {
+                message.append(EntityUtils.toString(entity));
+            } catch (IOException e) {
+                message.append("<<Error Reading Response Body>>");
+            }
+        }
+
+        return new AccessTokenEndpointException(message.toString());
+    }
+
     public AccessTokenEndpointException() {
     }
 

--- a/src/main/java/org/zalando/stups/tokens/AccessTokenRefresher.java
+++ b/src/main/java/org/zalando/stups/tokens/AccessTokenRefresher.java
@@ -151,7 +151,7 @@ class AccessTokenRefresher implements AccessTokens, Runnable {
                 // success status code?
                 final int status = response.getStatusLine().getStatusCode();
                 if (status < 200 || status >= 300) {
-                    throw new AccessTokenEndpointException(response.getStatusLine().toString());
+                    throw AccessTokenEndpointException.from(response);
                 }
 
                 // get json response


### PR DESCRIPTION
While working with this library I've often found myself trying to find out why something went wrong (tbh I mixed up my URL configuration). The auth server's response often times includes helpful information.

Therefore the response is included in the exception information (if it's available).