### PR TITLE
Lazy initialize provider

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,11 @@
     </developers>
 
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <java.source>1.8</java.source>
+        <java.target>1.8</java.target>
+
         <coveralls.dryRun>true</coveralls.dryRun>
         <main.basedir>${basedir}</main.basedir>
     </properties>
@@ -117,8 +122,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.3</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>${java.source}</source>
+                    <target>${java.target}</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/org/zalando/stups/tokens/AbstractJsonFileBackedCredentialsProvider.java
+++ b/src/main/java/org/zalando/stups/tokens/AbstractJsonFileBackedCredentialsProvider.java
@@ -18,11 +18,12 @@ package org.zalando.stups.tokens;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.File;
+import java.util.function.Supplier;
 
 public abstract class AbstractJsonFileBackedCredentialsProvider {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
-    private final File file;
+    private final Supplier<File> fileSupplier;
 
     private static File getCredentialsDir() {
         final String dir = System.getenv("CREDENTIALS_DIR");
@@ -33,20 +34,20 @@ public abstract class AbstractJsonFileBackedCredentialsProvider {
     }
 
     public AbstractJsonFileBackedCredentialsProvider(final String filename) {
-        this(new File(getCredentialsDir(), filename));
+        this.fileSupplier = () -> new File(getCredentialsDir(), filename);
     }
 
     public AbstractJsonFileBackedCredentialsProvider(final File file) {
-        this.file = file;
+        this.fileSupplier = () -> file;
     }
 
     protected File getFile() {
-        return file;
+        return fileSupplier.get();
     }
 
     protected  <T> T read(final Class<T> cls) {
         try {
-            return OBJECT_MAPPER.readValue(file, cls);
+            return OBJECT_MAPPER.readValue(getFile(), cls);
         } catch (final Throwable e) {
             throw new CredentialsUnavailableException(e.getMessage(), e);
         }


### PR DESCRIPTION
When using the cool new feature of ``OAUTH2_ACCESS_TOKENS`` you still need to have ``CREDENTIALS_DIR`` set and filled with the credentials file, since the ``AbstractJsonFileBackedCredentialsProvider`` is checking for their existence on creation. While you could prevent the creation of your provider classes, having them access the respective credential file lazy enables you to have the best of both worlds.

Questionable things this PR changes:
* Bump to Java 8
* If the credentials file cannot be found this exception will now be thrown on ``AccessTokenRefresher``'s thread