### PR TITLE
Allow users to provide their own http client.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,7 @@
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
             <version>4.3.6</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/src/main/java/org/zalando/stups/tokens/AbstractHttpProvider.java
+++ b/src/main/java/org/zalando/stups/tokens/AbstractHttpProvider.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (C) 2015 Zalando SE (http://tech.zalando.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zalando.stups.tokens;
+
+import java.util.Collection;
+import java.util.Iterator;
+
+public abstract class AbstractHttpProvider implements HttpProvider{
+    public String joinScopes(final Collection<Object> scopes) {
+        final Iterator<Object> iter = scopes.iterator();
+
+        final StringBuilder scope = new StringBuilder(iter.next().toString());
+        while (iter.hasNext()) {
+            scope.append(' ');
+            scope.append(iter.next().toString());
+        }
+
+        return scope.toString();
+    }
+}

--- a/src/main/java/org/zalando/stups/tokens/AccessTokenRefresher.java
+++ b/src/main/java/org/zalando/stups/tokens/AccessTokenRefresher.java
@@ -82,7 +82,7 @@ class AccessTokenRefresher implements AccessTokens, Runnable {
         final ClientCredentials clientCredentials = configuration.getClientCredentialsProvider().get();
         final UserCredentials userCredentials = configuration.getUserCredentialsProvider().get();
         httpProvider = configuration.getHttpProviderFactory().create(clientCredentials,
-                userCredentials, configuration.getAccessTokenUri());
+                userCredentials, configuration.getAccessTokenUri(), configuration.getHttpConfig());
         run();
 
         // #10, increase 'period' to 5 to avoid flooding the endpoint

--- a/src/main/java/org/zalando/stups/tokens/AccessTokenRefresher.java
+++ b/src/main/java/org/zalando/stups/tokens/AccessTokenRefresher.java
@@ -37,11 +37,13 @@ class AccessTokenRefresher implements AccessTokens, Runnable {
     private final TokenRefresherConfiguration configuration;
     private final ScheduledExecutorService scheduler;
     private HttpProvider httpProvider;
+    private final int schedulingPeriod;
 
     private ConcurrentHashMap<Object, AccessToken> accessTokens = new ConcurrentHashMap<Object, AccessToken>();
 
     public AccessTokenRefresher(final TokenRefresherConfiguration configuration) {
         this.configuration = configuration;
+        this.schedulingPeriod = configuration.getSchedulingPeriod();
         scheduler = Executors.newSingleThreadScheduledExecutor();
 
     }
@@ -86,7 +88,7 @@ class AccessTokenRefresher implements AccessTokens, Runnable {
         run();
 
         // #10, increase 'period' to 5 to avoid flooding the endpoint
-        scheduler.scheduleAtFixedRate(this, 1, 5, TimeUnit.SECONDS);
+        scheduler.scheduleAtFixedRate(this, 1, schedulingPeriod, TimeUnit.SECONDS);
     }
 
     static int percentLeft(final AccessToken token) {

--- a/src/main/java/org/zalando/stups/tokens/AccessTokenRefresher.java
+++ b/src/main/java/org/zalando/stups/tokens/AccessTokenRefresher.java
@@ -15,58 +15,35 @@
  */
 package org.zalando.stups.tokens;
 
-import java.util.ArrayList;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.util.Collection;
 import java.util.Date;
 import java.util.Iterator;
-import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpHost;
-import org.apache.http.NameValuePair;
-import org.apache.http.auth.AuthScope;
-import org.apache.http.auth.UsernamePasswordCredentials;
-import org.apache.http.client.AuthCache;
-import org.apache.http.client.CredentialsProvider;
-import org.apache.http.client.entity.UrlEncodedFormEntity;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.protocol.HttpClientContext;
-import org.apache.http.impl.auth.BasicScheme;
-import org.apache.http.impl.client.BasicAuthCache;
-import org.apache.http.impl.client.BasicCredentialsProvider;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
-import org.apache.http.message.BasicNameValuePair;
-import org.apache.http.util.EntityUtils;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 class AccessTokenRefresher implements AccessTokens, Runnable {
     private static final Logger LOG = LoggerFactory.getLogger(AccessTokenRefresher.class);
-
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     private static final long ONE_YEAR_SECONDS = 3600 * 24 * 365;
     private static final String FIXED_TOKENS_ENV_VAR = "OAUTH2_ACCESS_TOKENS";
 
-    private final AccessTokensBuilder configuration;
+    private final TokenRefresherConfiguration configuration;
     private final ScheduledExecutorService scheduler;
+    private HttpProvider httpProvider;
 
     private ConcurrentHashMap<Object, AccessToken> accessTokens = new ConcurrentHashMap<Object, AccessToken>();
 
-    public AccessTokenRefresher(final AccessTokensBuilder configuration) {
+    public AccessTokenRefresher(final TokenRefresherConfiguration configuration) {
         this.configuration = configuration;
         scheduler = Executors.newSingleThreadScheduledExecutor();
+
     }
 
     protected void initializeFixedTokensFromEnvironment() {
@@ -102,6 +79,10 @@ class AccessTokenRefresher implements AccessTokens, Runnable {
     void start() {
         initializeFixedTokensFromEnvironment();
         LOG.info("Starting to refresh tokens regularly...");
+        final ClientCredentials clientCredentials = configuration.getClientCredentialsProvider().get();
+        final UserCredentials userCredentials = configuration.getUserCredentialsProvider().get();
+        httpProvider = configuration.getHttpProviderFactory().create(clientCredentials,
+                userCredentials, configuration.getAccessTokenUri());
         run();
 
         // #10, increase 'period' to 5 to avoid flooding the endpoint
@@ -116,11 +97,11 @@ class AccessTokenRefresher implements AccessTokens, Runnable {
         return (int) ((double) secondsLeft / (double) hundredPercentSeconds * (double) 100);
     }
 
-    static boolean shouldRefresh(final AccessToken token, final AccessTokensBuilder configuration) {
+    static boolean shouldRefresh(final AccessToken token, final TokenRefresherConfiguration configuration) {
         return percentLeft(token) <= configuration.getRefreshPercentLeft();
     }
 
-    static boolean shouldWarn(final AccessToken token, final AccessTokensBuilder configuration) {
+    static boolean shouldWarn(final AccessToken token, final TokenRefresherConfiguration configuration) {
         return percentLeft(token) <= configuration.getWarnPercentLeft();
     }
 
@@ -153,85 +134,12 @@ class AccessTokenRefresher implements AccessTokens, Runnable {
         }
     }
 
-    private static String joinScopes(final Collection<Object> scopes) {
-        final Iterator<Object> iter = scopes.iterator();
-
-        final StringBuilder scope = new StringBuilder(iter.next().toString());
-        while (iter.hasNext()) {
-            scope.append(' ');
-            scope.append(iter.next().toString());
-        }
-
-        return scope.toString();
-    }
 
     private AccessToken createToken(final AccessTokenConfiguration tokenConfig) {
         try {
-
-            // collect credentials
-            final ClientCredentials clientCredentials = configuration.getClientCredentialsProvider().get();
-            final UserCredentials userCredentials = configuration.getUserCredentialsProvider().get();
-
-            // prepare basic auth credentials
-            final CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
-            credentialsProvider.setCredentials(new AuthScope(configuration.getAccessTokenUri().getHost(),
-                    configuration.getAccessTokenUri().getPort()),
-                new UsernamePasswordCredentials(clientCredentials.getId(), clientCredentials.getSecret()));
-
-            // create a new client that targets our host with basic auth enabled
-            final CloseableHttpClient client = HttpClients.custom().setDefaultCredentialsProvider(credentialsProvider)
-                                                          .build();
-            final HttpHost host = new HttpHost(configuration.getAccessTokenUri().getHost(),
-                    configuration.getAccessTokenUri().getPort(), configuration.getAccessTokenUri().getScheme());
-            final HttpPost request = new HttpPost(configuration.getAccessTokenUri());
-
-            // prepare the request body
-
-            final List<NameValuePair> values = new ArrayList<NameValuePair>() {
-
-                {
-                    add(new BasicNameValuePair("grant_type", "password"));
-                    add(new BasicNameValuePair("username", userCredentials.getUsername()));
-                    add(new BasicNameValuePair("password", userCredentials.getPassword()));
-                    add(new BasicNameValuePair("scope", joinScopes(tokenConfig.getScopes())));
-                }
-            };
-            request.setEntity(new UrlEncodedFormEntity(values));
-
-            // enable basic auth for the request
-            final AuthCache authCache = new BasicAuthCache();
-            final BasicScheme basicAuth = new BasicScheme();
-            authCache.put(host, basicAuth);
-
-            final HttpClientContext localContext = HttpClientContext.create();
-            localContext.setAuthCache(authCache);
-
-            // execute!
-            final CloseableHttpResponse response = client.execute(host, request, localContext);
-            try {
-
-                // success status code?
-                final int status = response.getStatusLine().getStatusCode();
-                if (status < 200 || status >= 300) {
-                    throw AccessTokenEndpointException.from(response);
-                }
-
-                // get json response
-                final HttpEntity entity = response.getEntity();
-                final AccessTokenResponse accessTokenResponse = OBJECT_MAPPER.readValue(EntityUtils.toByteArray(entity),
-                        AccessTokenResponse.class);
-
-                // create new access token object
-                final Date validUntil = new Date(System.currentTimeMillis()
-                            + (accessTokenResponse.expiresInSeconds * 1000));
-
-                return new AccessToken(accessTokenResponse.getAccessToken(), accessTokenResponse.getTokenType(),
-                        accessTokenResponse.getExpiresInSeconds(), validUntil);
-            } finally {
-                response.close();
-            }
-        } catch (Throwable t) {
-            throw new AccessTokenEndpointException(t.getMessage(), t);
+            return httpProvider.createToken(tokenConfig);
+        } catch (RuntimeException | UnsupportedEncodingException e) {
+            throw new AccessTokenEndpointException(e.getMessage(), e);
         }
     }
 
@@ -262,29 +170,10 @@ class AccessTokenRefresher implements AccessTokens, Runnable {
     @Override
     public void stop() {
         scheduler.shutdown();
-    }
-
-    @JsonIgnoreProperties(ignoreUnknown = true)
-    private static final class AccessTokenResponse {
-        @JsonProperty("access_token")
-        private String accessToken;
-
-        @JsonProperty("token_type")
-        private String tokenType;
-
-        @JsonProperty("expires_in")
-        private long expiresInSeconds;
-
-        public String getAccessToken() {
-            return accessToken;
-        }
-
-        public String getTokenType() {
-            return tokenType;
-        }
-
-        public long getExpiresInSeconds() {
-            return expiresInSeconds;
+        try {
+            httpProvider.close();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
         }
     }
 }

--- a/src/main/java/org/zalando/stups/tokens/AccessTokenResponse.java
+++ b/src/main/java/org/zalando/stups/tokens/AccessTokenResponse.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) 2015 Zalando SE (http://tech.zalando.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zalando.stups.tokens;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public final class AccessTokenResponse {
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    @JsonProperty("token_type")
+    private String tokenType;
+
+    @JsonProperty("expires_in")
+    private long expiresInSeconds;
+
+    public String getAccessToken() {
+        return accessToken;
+    }
+
+    public String getTokenType() {
+        return tokenType;
+    }
+
+    public long getExpiresInSeconds() {
+        return expiresInSeconds;
+    }
+}

--- a/src/main/java/org/zalando/stups/tokens/AccessTokensBuilder.java
+++ b/src/main/java/org/zalando/stups/tokens/AccessTokensBuilder.java
@@ -21,7 +21,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
-public class AccessTokensBuilder {
+public class AccessTokensBuilder implements TokenRefresherConfiguration {
     private final URI accessTokenUri;
 
     private ClientCredentialsProvider clientCredentialsProvider = null;
@@ -32,6 +32,7 @@ public class AccessTokensBuilder {
     private final Set<AccessTokenConfiguration> accessTokenConfigurations = new HashSet<AccessTokenConfiguration>();
 
     private boolean locked = false;
+    private HttpProviderFactory httpProviderFactory;
 
     AccessTokensBuilder(final URI accessTokenUri) {
         this.accessTokenUri = accessTokenUri;
@@ -64,6 +65,11 @@ public class AccessTokensBuilder {
         return this;
     }
 
+    public AccessTokensBuilder usingHttpProviderFactory(HttpProviderFactory factory) {
+        this.httpProviderFactory = factory;
+        return this;
+    }
+
     public AccessTokensBuilder refreshPercentLeft(final int refreshPercentLeft) {
         checkLock();
         this.refreshPercentLeft = refreshPercentLeft;
@@ -85,27 +91,32 @@ public class AccessTokensBuilder {
         return config;
     }
 
-    URI getAccessTokenUri() {
+    public URI getAccessTokenUri() {
         return accessTokenUri;
     }
 
-    ClientCredentialsProvider getClientCredentialsProvider() {
+    @Override
+    public HttpProviderFactory getHttpProviderFactory() {
+        return this.httpProviderFactory;
+    }
+
+    public ClientCredentialsProvider getClientCredentialsProvider() {
         return clientCredentialsProvider;
     }
 
-    UserCredentialsProvider getUserCredentialsProvider() {
+    public UserCredentialsProvider getUserCredentialsProvider() {
         return userCredentialsProvider;
     }
 
-    int getRefreshPercentLeft() {
+    public int getRefreshPercentLeft() {
         return refreshPercentLeft;
     }
 
-    int getWarnPercentLeft() {
+    public int getWarnPercentLeft() {
         return warnPercentLeft;
     }
 
-    Set<AccessTokenConfiguration> getAccessTokenConfigurations() {
+    public Set<AccessTokenConfiguration> getAccessTokenConfigurations() {
         return Collections.unmodifiableSet(accessTokenConfigurations);
     }
 
@@ -125,6 +136,9 @@ public class AccessTokensBuilder {
 
             // use default
             userCredentialsProvider = new JsonFileBackedUserCredentialsProvider();
+        }
+        if(httpProviderFactory == null) {
+            this.httpProviderFactory = new ClosableHttpProviderFactory();
         }
 
         final AccessTokenRefresher refresher = getAccessTokenRefresher();

--- a/src/main/java/org/zalando/stups/tokens/AccessTokensBuilder.java
+++ b/src/main/java/org/zalando/stups/tokens/AccessTokensBuilder.java
@@ -29,6 +29,7 @@ public class AccessTokensBuilder implements TokenRefresherConfiguration {
     private int refreshPercentLeft = 40;
     private int warnPercentLeft = 20;
 
+    private final HttpConfig httpConfig = new HttpConfig();
     private final Set<AccessTokenConfiguration> accessTokenConfigurations = new HashSet<AccessTokenConfiguration>();
 
     private boolean locked = false;
@@ -66,7 +67,32 @@ public class AccessTokensBuilder implements TokenRefresherConfiguration {
     }
 
     public AccessTokensBuilder usingHttpProviderFactory(HttpProviderFactory factory) {
+        checkLock();
         this.httpProviderFactory = factory;
+        return this;
+    }
+
+    public AccessTokensBuilder socketTimeout(final int socketTimeout){
+        checkLock();
+        this.httpConfig.setSocketTimeout(socketTimeout);
+        return this;
+    }
+
+    public AccessTokensBuilder connectTimeout(final int connectTimeout){
+        checkLock();
+        this.httpConfig.setConnectTimeout(connectTimeout);
+        return this;
+    }
+
+    public AccessTokensBuilder connectionRequestTimeout(final int connectionRequestTimeout){
+        checkLock();
+        this.httpConfig.setConnectionRequestTimeout(connectionRequestTimeout);
+        return this;
+    }
+
+    public AccessTokensBuilder staleConnectionCheckEnabled(final boolean staleConnectionCheckEnabled){
+        checkLock();
+        this.httpConfig.setStaleConnectionCheckEnabled(staleConnectionCheckEnabled);
         return this;
     }
 
@@ -144,6 +170,10 @@ public class AccessTokensBuilder implements TokenRefresherConfiguration {
         final AccessTokenRefresher refresher = getAccessTokenRefresher();
         refresher.start();
         return refresher;
+    }
+
+    public HttpConfig getHttpConfig() {
+        return httpConfig;
     }
 
     protected AccessTokenRefresher getAccessTokenRefresher() {

--- a/src/main/java/org/zalando/stups/tokens/AccessTokensBuilder.java
+++ b/src/main/java/org/zalando/stups/tokens/AccessTokensBuilder.java
@@ -34,6 +34,7 @@ public class AccessTokensBuilder implements TokenRefresherConfiguration {
 
     private boolean locked = false;
     private HttpProviderFactory httpProviderFactory;
+    private int schedulingPeriod = 5;
 
     AccessTokensBuilder(final URI accessTokenUri) {
         this.accessTokenUri = accessTokenUri;
@@ -115,6 +116,16 @@ public class AccessTokensBuilder implements TokenRefresherConfiguration {
         final AccessTokenConfiguration config = new AccessTokenConfiguration(tokenId, this);
         accessTokenConfigurations.add(config);
         return config;
+    }
+
+    public AccessTokensBuilder schedulingPeriod(final int schedulingPeriod){
+        checkLock();
+        this.schedulingPeriod = schedulingPeriod;
+        return this;
+    }
+
+    public int getSchedulingPeriod() {
+        return schedulingPeriod;
     }
 
     public URI getAccessTokenUri() {

--- a/src/main/java/org/zalando/stups/tokens/ClosableHttpProviderFactory.java
+++ b/src/main/java/org/zalando/stups/tokens/ClosableHttpProviderFactory.java
@@ -19,7 +19,10 @@ import java.net.URI;
 
 public class ClosableHttpProviderFactory implements HttpProviderFactory {
     @Override
-    public HttpProvider create(ClientCredentials clientCredentials, UserCredentials userCredentials, URI accessTokenUri) {
-        return new CloseableHttpProvider(clientCredentials, userCredentials, accessTokenUri);
+    public HttpProvider create(ClientCredentials clientCredentials,
+                               UserCredentials userCredentials,
+                               URI accessTokenUri,
+                               HttpConfig httpConfig) {
+        return new CloseableHttpProvider(clientCredentials, userCredentials, accessTokenUri, httpConfig);
     }
 }

--- a/src/main/java/org/zalando/stups/tokens/ClosableHttpProviderFactory.java
+++ b/src/main/java/org/zalando/stups/tokens/ClosableHttpProviderFactory.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (C) 2015 Zalando SE (http://tech.zalando.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zalando.stups.tokens;
+
+import java.net.URI;
+
+public class ClosableHttpProviderFactory implements HttpProviderFactory {
+    @Override
+    public HttpProvider create(ClientCredentials clientCredentials, UserCredentials userCredentials, URI accessTokenUri) {
+        return new CloseableHttpProvider(clientCredentials, userCredentials, accessTokenUri);
+    }
+}

--- a/src/main/java/org/zalando/stups/tokens/CloseableHttpProvider.java
+++ b/src/main/java/org/zalando/stups/tokens/CloseableHttpProvider.java
@@ -23,6 +23,7 @@ import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.AuthCache;
 import org.apache.http.client.CredentialsProvider;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
@@ -51,10 +52,20 @@ public class CloseableHttpProvider extends AbstractHttpProvider {
     private UserCredentials userCredentials;
     private URI accessTokenUri;
     private final HttpHost host;
+    private final RequestConfig requestConfig;
 
-    public CloseableHttpProvider(ClientCredentials clientCredentials, UserCredentials userCredentials, URI accessTokenUri) {
+    public CloseableHttpProvider(ClientCredentials clientCredentials,
+                                 UserCredentials userCredentials,
+                                 URI accessTokenUri,
+                                 HttpConfig httpConfig) {
         this.userCredentials = userCredentials;
         this.accessTokenUri = accessTokenUri;
+        requestConfig = RequestConfig.custom()
+                    	        .setSocketTimeout(httpConfig.getSocketTimeout())
+                    	        .setConnectTimeout(httpConfig.getConnectTimeout())
+                    	        .setConnectionRequestTimeout(httpConfig.getConnectionRequestTimeout())
+                    	        .setStaleConnectionCheckEnabled(httpConfig.isStaleConnectionCheckEnabled())
+                    	        .build();
 
         // prepare basic auth credentials
         final CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
@@ -82,6 +93,7 @@ public class CloseableHttpProvider extends AbstractHttpProvider {
 
         final HttpPost request = new HttpPost(accessTokenUri);
         request.setEntity(new UrlEncodedFormEntity(values));
+        request.setConfig(requestConfig);
 
         try (final CloseableHttpResponse response = client.execute(host, request, localContext)) {
 

--- a/src/main/java/org/zalando/stups/tokens/CloseableHttpProvider.java
+++ b/src/main/java/org/zalando/stups/tokens/CloseableHttpProvider.java
@@ -1,0 +1,123 @@
+/**
+ * Copyright (C) 2015 Zalando SE (http://tech.zalando.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zalando.stups.tokens;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpHost;
+import org.apache.http.NameValuePair;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.AuthCache;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.impl.auth.BasicScheme;
+import org.apache.http.impl.client.BasicAuthCache;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.message.BasicNameValuePair;
+import org.apache.http.util.EntityUtils;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+public class CloseableHttpProvider extends AbstractHttpProvider {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private final CloseableHttpClient client;
+    private final HttpClientContext localContext;
+    private UserCredentials userCredentials;
+    private URI accessTokenUri;
+    private final HttpHost host;
+
+    public CloseableHttpProvider(ClientCredentials clientCredentials, UserCredentials userCredentials, URI accessTokenUri) {
+        this.userCredentials = userCredentials;
+        this.accessTokenUri = accessTokenUri;
+
+        // prepare basic auth credentials
+        final CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+        credentialsProvider.setCredentials(new AuthScope(accessTokenUri.getHost(),
+                        accessTokenUri.getPort()),
+                new UsernamePasswordCredentials(clientCredentials.getId(), clientCredentials.getSecret()));
+
+        client = HttpClients.custom().setDefaultCredentialsProvider(credentialsProvider)
+                .build();
+
+        host = new HttpHost(accessTokenUri.getHost(),
+                accessTokenUri.getPort(), accessTokenUri.getScheme());
+
+        // enable basic auth for the request
+        final AuthCache authCache = new BasicAuthCache();
+        final BasicScheme basicAuth = new BasicScheme();
+        authCache.put(host, basicAuth);
+
+        localContext = HttpClientContext.create();
+        localContext.setAuthCache(authCache);
+    }
+
+    public AccessToken createToken(final AccessTokenConfiguration tokenConfig) throws UnsupportedEncodingException {
+        final List<NameValuePair> values = buildParameterList(tokenConfig);
+
+        final HttpPost request = new HttpPost(accessTokenUri);
+        request.setEntity(new UrlEncodedFormEntity(values));
+
+        try (final CloseableHttpResponse response = client.execute(host, request, localContext)) {
+
+            // success status code?
+            final int status = response.getStatusLine().getStatusCode();
+            if (status < 200 || status >= 300) {
+                throw AccessTokenEndpointException.from(response);
+            }
+
+            // get json response
+            final HttpEntity entity = response.getEntity();
+            final AccessTokenResponse accessTokenResponse = OBJECT_MAPPER.readValue(EntityUtils.toByteArray(entity),
+                    AccessTokenResponse.class);
+
+            // create new access token object
+            final Date validUntil = new Date(System.currentTimeMillis()
+                    + (accessTokenResponse.getExpiresInSeconds() * 1000));
+
+            return new AccessToken(accessTokenResponse.getAccessToken(), accessTokenResponse.getTokenType(),
+                    accessTokenResponse.getExpiresInSeconds(), validUntil);
+        } catch (Throwable t) {
+            throw new AccessTokenEndpointException(t.getMessage(), t);
+        }
+    }
+
+    private List<NameValuePair> buildParameterList(final AccessTokenConfiguration tokenConfig) {
+        List<NameValuePair> nameValuePairs = new ArrayList<>();
+        nameValuePairs.add(new BasicNameValuePair("grant_type", "password"));
+        nameValuePairs.add(new BasicNameValuePair("username", userCredentials.getUsername()));
+        nameValuePairs.add(new BasicNameValuePair("password", userCredentials.getPassword()));
+        nameValuePairs.add(new BasicNameValuePair("scope", joinScopes(tokenConfig.getScopes())));
+        return nameValuePairs;
+    }
+
+    @Override
+    public void close() throws IOException {
+        client.close();
+    }
+}

--- a/src/main/java/org/zalando/stups/tokens/HttpConfig.java
+++ b/src/main/java/org/zalando/stups/tokens/HttpConfig.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (C) 2015 Zalando SE (http://tech.zalando.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zalando.stups.tokens;
+
+public class HttpConfig {
+    private int socketTimeout = 2000;
+
+    private int connectTimeout = 1000;
+
+    private int connectionRequestTimeout = 500;
+
+    private boolean staleConnectionCheckEnabled = false;
+
+    private int schedulingPeriod = 5;
+
+    public int getSocketTimeout() {
+        return socketTimeout;
+    }
+
+    public void setSocketTimeout(int socketTimeout) {
+        this.socketTimeout = socketTimeout;
+    }
+
+    public int getConnectTimeout() {
+        return connectTimeout;
+    }
+
+    public void setConnectTimeout(int connectTimeout) {
+        this.connectTimeout = connectTimeout;
+    }
+
+    public int getConnectionRequestTimeout() {
+        return connectionRequestTimeout;
+    }
+
+    public void setConnectionRequestTimeout(int connectionRequestTimeout) {
+        this.connectionRequestTimeout = connectionRequestTimeout;
+    }
+
+    public boolean isStaleConnectionCheckEnabled() {
+        return staleConnectionCheckEnabled;
+    }
+
+    public void setStaleConnectionCheckEnabled(boolean staleConnectionCheckEnabled) {
+        this.staleConnectionCheckEnabled = staleConnectionCheckEnabled;
+    }
+
+    public int getSchedulingPeriod() {
+        return schedulingPeriod;
+    }
+
+    public void setSchedulingPeriod(int schedulingPeriod) {
+        this.schedulingPeriod = schedulingPeriod;
+    }
+}

--- a/src/main/java/org/zalando/stups/tokens/HttpProvider.java
+++ b/src/main/java/org/zalando/stups/tokens/HttpProvider.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (C) 2015 Zalando SE (http://tech.zalando.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zalando.stups.tokens;
+
+import java.io.Closeable;
+import java.io.UnsupportedEncodingException;
+
+public interface HttpProvider extends Closeable {
+
+    AccessToken createToken(final AccessTokenConfiguration tokenConfig) throws UnsupportedEncodingException;
+}

--- a/src/main/java/org/zalando/stups/tokens/HttpProviderFactory.java
+++ b/src/main/java/org/zalando/stups/tokens/HttpProviderFactory.java
@@ -19,5 +19,8 @@ import java.net.URI;
 
 public interface HttpProviderFactory {
 
-    HttpProvider create(ClientCredentials clientCredentials, UserCredentials userCredentials, URI accessTokenUri);
+    HttpProvider create(ClientCredentials clientCredentials,
+                        UserCredentials userCredentials,
+                        URI accessTokenUri,
+                        HttpConfig httpConfig);
 }

--- a/src/main/java/org/zalando/stups/tokens/HttpProviderFactory.java
+++ b/src/main/java/org/zalando/stups/tokens/HttpProviderFactory.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright (C) 2015 Zalando SE (http://tech.zalando.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zalando.stups.tokens;
+
+import java.net.URI;
+
+public interface HttpProviderFactory {
+
+    HttpProvider create(ClientCredentials clientCredentials, UserCredentials userCredentials, URI accessTokenUri);
+}

--- a/src/main/java/org/zalando/stups/tokens/TokenRefresherConfiguration.java
+++ b/src/main/java/org/zalando/stups/tokens/TokenRefresherConfiguration.java
@@ -32,4 +32,6 @@ public interface TokenRefresherConfiguration {
     URI getAccessTokenUri();
 
     HttpProviderFactory getHttpProviderFactory();
+
+    HttpConfig getHttpConfig();
 }

--- a/src/main/java/org/zalando/stups/tokens/TokenRefresherConfiguration.java
+++ b/src/main/java/org/zalando/stups/tokens/TokenRefresherConfiguration.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (C) 2015 Zalando SE (http://tech.zalando.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zalando.stups.tokens;
+
+import java.net.URI;
+import java.util.Set;
+
+public interface TokenRefresherConfiguration {
+    ClientCredentialsProvider getClientCredentialsProvider();
+
+    UserCredentialsProvider getUserCredentialsProvider();
+
+    int getRefreshPercentLeft();
+
+    int getWarnPercentLeft();
+
+    Set<AccessTokenConfiguration> getAccessTokenConfigurations();
+
+    URI getAccessTokenUri();
+
+    HttpProviderFactory getHttpProviderFactory();
+}

--- a/src/main/java/org/zalando/stups/tokens/TokenRefresherConfiguration.java
+++ b/src/main/java/org/zalando/stups/tokens/TokenRefresherConfiguration.java
@@ -34,4 +34,6 @@ public interface TokenRefresherConfiguration {
     HttpProviderFactory getHttpProviderFactory();
 
     HttpConfig getHttpConfig();
+
+    int getSchedulingPeriod();
 }


### PR DESCRIPTION
If users of the library have configured their own http client, e.g. the http-async-client,
they want to use this client for all requests. This commit removes the forced dependency
on the apache http client.

Users can now provide their own HttpProviderFactory to use a client of their choice.