### PR TITLE
Make ScheduledExecutorService configurable

### DIFF
--- a/src/main/java/org/zalando/stups/tokens/AccessTokensBuilder.java
+++ b/src/main/java/org/zalando/stups/tokens/AccessTokensBuilder.java
@@ -20,6 +20,8 @@ import java.net.URI;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 
 public class AccessTokensBuilder implements TokenRefresherConfiguration {
     private final URI accessTokenUri;
@@ -35,6 +37,7 @@ public class AccessTokensBuilder implements TokenRefresherConfiguration {
     private boolean locked = false;
     private HttpProviderFactory httpProviderFactory;
     private int schedulingPeriod = 5;
+    private ScheduledExecutorService executorService;
 
     AccessTokensBuilder(final URI accessTokenUri) {
         this.accessTokenUri = accessTokenUri;
@@ -67,31 +70,37 @@ public class AccessTokensBuilder implements TokenRefresherConfiguration {
         return this;
     }
 
-    public AccessTokensBuilder usingHttpProviderFactory(HttpProviderFactory factory) {
+    public AccessTokensBuilder usingHttpProviderFactory(final HttpProviderFactory factory) {
         checkLock();
         this.httpProviderFactory = factory;
         return this;
     }
 
-    public AccessTokensBuilder socketTimeout(final int socketTimeout){
+    public AccessTokensBuilder socketTimeout(final int socketTimeout) {
         checkLock();
         this.httpConfig.setSocketTimeout(socketTimeout);
         return this;
     }
 
-    public AccessTokensBuilder connectTimeout(final int connectTimeout){
+    public AccessTokensBuilder existingExecutorService(final ScheduledExecutorService executorService) {
+        checkLock();
+        this.executorService = executorService;
+        return this;
+    }
+
+    public AccessTokensBuilder connectTimeout(final int connectTimeout) {
         checkLock();
         this.httpConfig.setConnectTimeout(connectTimeout);
         return this;
     }
 
-    public AccessTokensBuilder connectionRequestTimeout(final int connectionRequestTimeout){
+    public AccessTokensBuilder connectionRequestTimeout(final int connectionRequestTimeout) {
         checkLock();
         this.httpConfig.setConnectionRequestTimeout(connectionRequestTimeout);
         return this;
     }
 
-    public AccessTokensBuilder staleConnectionCheckEnabled(final boolean staleConnectionCheckEnabled){
+    public AccessTokensBuilder staleConnectionCheckEnabled(final boolean staleConnectionCheckEnabled) {
         checkLock();
         this.httpConfig.setStaleConnectionCheckEnabled(staleConnectionCheckEnabled);
         return this;
@@ -118,7 +127,7 @@ public class AccessTokensBuilder implements TokenRefresherConfiguration {
         return config;
     }
 
-    public AccessTokensBuilder schedulingPeriod(final int schedulingPeriod){
+    public AccessTokensBuilder schedulingPeriod(final int schedulingPeriod) {
         checkLock();
         this.schedulingPeriod = schedulingPeriod;
         return this;
@@ -149,6 +158,14 @@ public class AccessTokensBuilder implements TokenRefresherConfiguration {
         return refreshPercentLeft;
     }
 
+    public ScheduledExecutorService getExecutorService() {
+        if (executorService == null) {
+            return Executors.newSingleThreadScheduledExecutor();
+        } else {
+            return executorService;
+        }
+    }
+
     public int getWarnPercentLeft() {
         return warnPercentLeft;
     }
@@ -174,7 +191,8 @@ public class AccessTokensBuilder implements TokenRefresherConfiguration {
             // use default
             userCredentialsProvider = new JsonFileBackedUserCredentialsProvider();
         }
-        if(httpProviderFactory == null) {
+
+        if (httpProviderFactory == null) {
             this.httpProviderFactory = new ClosableHttpProviderFactory();
         }
 

--- a/src/main/java/org/zalando/stups/tokens/TokenRefresherConfiguration.java
+++ b/src/main/java/org/zalando/stups/tokens/TokenRefresherConfiguration.java
@@ -16,7 +16,9 @@
 package org.zalando.stups.tokens;
 
 import java.net.URI;
+
 import java.util.Set;
+import java.util.concurrent.ScheduledExecutorService;
 
 public interface TokenRefresherConfiguration {
     ClientCredentialsProvider getClientCredentialsProvider();
@@ -36,4 +38,6 @@ public interface TokenRefresherConfiguration {
     HttpConfig getHttpConfig();
 
     int getSchedulingPeriod();
+
+    ScheduledExecutorService getExecutorService();
 }


### PR DESCRIPTION
It would be nice to be able to pass in an existing ScheduledExecutorService instead of eagerly creating an existing one. That way we could manage the tokens for different services separately without spawning threads all over the place