### PR TITLE
Use system properties when constructing the HttpClient

### DIFF
--- a/src/main/java/org/zalando/stups/tokens/CloseableHttpProvider.java
+++ b/src/main/java/org/zalando/stups/tokens/CloseableHttpProvider.java
@@ -74,7 +74,9 @@ public class CloseableHttpProvider extends AbstractHttpProvider {
                         accessTokenUri.getPort()),
                 new UsernamePasswordCredentials(clientCredentials.getId(), clientCredentials.getSecret()));
 
-        client = HttpClients.custom().setDefaultCredentialsProvider(credentialsProvider)
+        client = HttpClients.custom()
+                .useSystemProperties()
+                .setDefaultCredentialsProvider(credentialsProvider)
                 .build();
 
         host = new HttpHost(accessTokenUri.getHost(),


### PR DESCRIPTION
so that JVM Proxy settings will be used (if present).

Proxy settings are here need by on-premise systems to talk to cloud systems, passing the data center boundaries through a HTTP(S) proxy. JVM default system properties seem to be a straight forward way to configure this.