### PR TITLE
move try-catch to handle every configuration for its own, to avoid

### DIFF
--- a/src/main/java/org/zalando/stups/tokens/AccessTokenRefresher.java
+++ b/src/main/java/org/zalando/stups/tokens/AccessTokenRefresher.java
@@ -117,8 +117,7 @@ class AccessTokenRefresher implements AccessTokens, Runnable {
                         LOG.info("Refreshed access token {}.", tokenConfig.getTokenId());
                     } catch (final Throwable t) {
                         if (oldToken == null || shouldWarn(oldToken, configuration)) {
-                            LOG.warn("Cannot refresh access token {} because {}.", tokenConfig.getTokenId(),
-                                    t.getMessage(), t);
+                            LOG.warn("Cannot refresh access token {} because {}.", tokenConfig.getTokenId(), t);
                         } else {
                             LOG.info("Cannot refresh access token {} because {}.", tokenConfig.getTokenId(), t);
                         }

--- a/src/main/java/org/zalando/stups/tokens/AccessTokenRefresher.java
+++ b/src/main/java/org/zalando/stups/tokens/AccessTokenRefresher.java
@@ -16,8 +16,6 @@
 package org.zalando.stups.tokens;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-
 import java.util.Date;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledExecutorService;
@@ -25,7 +23,6 @@ import java.util.concurrent.TimeUnit;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import org.zalando.stups.tokens.util.Objects;
 
 class AccessTokenRefresher implements AccessTokens, Runnable {
@@ -90,7 +87,7 @@ class AccessTokenRefresher implements AccessTokens, Runnable {
         final long validUntil = token.getValidUntil().getTime();
         final long hundredPercentSeconds = token.getInitialValidSeconds();
         final long secondsLeft = (validUntil - now) / 1000;
-        return (int) ((double) secondsLeft / (double) hundredPercentSeconds * (double) 100);
+        return (int) ((double) secondsLeft / (double) hundredPercentSeconds * 100);
     }
 
     static boolean shouldRefresh(final AccessToken token, final TokenRefresherConfiguration configuration) {
@@ -103,32 +100,33 @@ class AccessTokenRefresher implements AccessTokens, Runnable {
 
     @Override
     public void run() {
-        try {
-            for (final AccessTokenConfiguration tokenConfig : configuration.getAccessTokenConfigurations()) {
+        for (final AccessTokenConfiguration tokenConfig : configuration.getAccessTokenConfigurations()) {
+            try {
                 final AccessToken oldToken = accessTokens.get(tokenConfig.getTokenId());
 
-                // TODO optionally check with tokeninfo endpoint regularly (every x% of time)
+                // TODO optionally check with tokeninfo endpoint regularly
+                // (every x% of time)
                 if (oldToken == null || shouldRefresh(oldToken, configuration)) {
                     try {
                         LOG.trace("Refreshing access token {}...", tokenConfig.getTokenId());
 
                         final AccessToken newToken = createToken(tokenConfig);
-                        //validate
+                        // validate
                         Objects.notNull("newToken", newToken);
                         accessTokens.put(tokenConfig.getTokenId(), newToken);
                         LOG.info("Refreshed access token {}.", tokenConfig.getTokenId());
                     } catch (final Throwable t) {
                         if (oldToken == null || shouldWarn(oldToken, configuration)) {
-                            LOG.warn("Cannot refresh access token {} because {}.", tokenConfig.getTokenId(), t.getMessage(), t);
+                            LOG.warn("Cannot refresh access token {} because {}.", tokenConfig.getTokenId(),
+                                    t.getMessage(), t);
                         } else {
                             LOG.info("Cannot refresh access token {} because {}.", tokenConfig.getTokenId(), t);
                         }
                     }
                 }
-
+            } catch (Throwable t) {
+                LOG.warn("Unexpected problem during token refresh run! TokenId: {}", tokenConfig.getTokenId(), t);
             }
-        } catch (final Throwable t) {
-            LOG.error("Unexpected problem during token refresh run!", t);
         }
     }
 

--- a/src/main/java/org/zalando/stups/tokens/AccessTokenRefresher.java
+++ b/src/main/java/org/zalando/stups/tokens/AccessTokenRefresher.java
@@ -117,14 +117,14 @@ class AccessTokenRefresher implements AccessTokens, Runnable {
                         LOG.info("Refreshed access token {}.", tokenConfig.getTokenId());
                     } catch (final Throwable t) {
                         if (oldToken == null || shouldWarn(oldToken, configuration)) {
-                            LOG.warn("Cannot refresh access token {} because {}.", tokenConfig.getTokenId(), t);
+                            LOG.warn("Cannot refresh access token " + tokenConfig.getTokenId(), t);
                         } else {
                             LOG.info("Cannot refresh access token {} because {}.", tokenConfig.getTokenId(), t);
                         }
                     }
                 }
             } catch (Throwable t) {
-                LOG.warn("Unexpected problem during token refresh run! TokenId: {}", tokenConfig.getTokenId(), t);
+                LOG.warn("Unexpected problem during token refresh run! TokenId: " + tokenConfig.getTokenId(), t);
             }
         }
     }

--- a/src/test/java/org/zalando/stups/tokens/AccessTokenRefresherRunTest.java
+++ b/src/test/java/org/zalando/stups/tokens/AccessTokenRefresherRunTest.java
@@ -54,6 +54,7 @@ public class AccessTokenRefresherRunTest {
 		}
 	}
 
+    //@formatter:off
 	@Test
 	public void runAccessTokenRefresher() throws IOException, InterruptedException {
 		File tempDir = tempFolder.newFolder();
@@ -67,8 +68,16 @@ public class AccessTokenRefresherRunTest {
 		UserCredentialsProvider ucp = Mockito.mock(UserCredentialsProvider.class);
 		HttpProviderFactory hpf = Mockito.mock(HttpProviderFactory.class);
 
-		AccessTokensBuilder accessTokenBuilder = Tokens.createAccessTokensWithUri(uri).usingClientCredentialsProvider(ccp)
-				.usingUserCredentialsProvider(ucp).usingHttpProviderFactory(hpf).manageToken("TR_TEST").done();
+		AccessTokensBuilder accessTokenBuilder = Tokens.createAccessTokensWithUri(uri)
+		                                               .usingClientCredentialsProvider(ccp)
+		                                               .usingUserCredentialsProvider(ucp)
+		                                               .usingHttpProviderFactory(hpf)
+		                                               .manageToken("TR_TEST")
+		                                               .done()
+		                                               .manageToken("TR_TEST_1")
+		                                               .done()
+		                                               .manageToken("TR_TEST_2")
+                                                       .done();
 
 		HttpProvider httpProvider = Mockito.mock(HttpProvider.class);
 
@@ -76,7 +85,12 @@ public class AccessTokenRefresherRunTest {
 				Mockito.any(URI.class), Mockito.any(HttpConfig.class))).thenReturn(httpProvider);
 
 		Mockito.when(httpProvider.createToken(Mockito.any(AccessTokenConfiguration.class)))
-				.thenReturn(new AccessToken("123456789", "BEARER", 2, new Date(System.currentTimeMillis() + 15000)));
+                .thenReturn(new AccessToken("123456789", "BEARER", 2, new Date(System.currentTimeMillis() + 15000)))
+                .thenThrow(new RuntimeException("DO NOT FAIL ALL CONFIGURATIONS"))
+                .thenReturn(new AccessToken("123456789", "BEARER", 2, new Date(System.currentTimeMillis() + 15000)))
+                .thenReturn(new AccessToken("123456789", "BEARER", 2, new Date(System.currentTimeMillis() + 15000)))
+                .thenThrow(new RuntimeException("DO NOT FAIL ALL CONFIGURATIONS"))
+                .thenReturn(new AccessToken("123456789", "BEARER", 2, new Date(System.currentTimeMillis() + 15000)));
 		accessTokens = accessTokenBuilder.start();
 		Assertions.assertThat(accessTokens).isNotNull();
 
@@ -85,6 +99,7 @@ public class AccessTokenRefresherRunTest {
 		Mockito.verify(httpProvider, Mockito.atLeastOnce()).createToken(Mockito.any(AccessTokenConfiguration.class));
 
 	}
+	//@formatter:on
 
 	/**
 	 * Verifies that if a fixed token is set and the default configuration used, no attempt to refresh it using an


### PR DESCRIPTION
that following configurations are skipped when for example the first has
any exceptions

fixes #38 